### PR TITLE
Normalize title can't find the namespace when Title::newFromDBkey is …

### DIFF
--- a/OpenGraphMeta.php
+++ b/OpenGraphMeta.php
@@ -44,7 +44,7 @@ function efSetMainImagePF( $parser, $mainimage ) {
 
 $wgParserOutputHooks['setmainimage'] = 'efSetMainImagePH';
 function efSetMainImagePH( $out, $parserOutput, $data ) {
-	$out->mMainImage = wfFindFile( Title::newFromDBkey($data['dbkey'], NS_FILE) );
+	$out->mMainImage = wfFindFile($data['dbkey']);
 }
 
 $wgHooks['BeforePageDisplay'][] = 'efOpenGraphMetaPageHook';


### PR DESCRIPTION
Normalize title can't find the namespace (for articles in the main namespace) when Title::newFromDBkey is used.