### PR TITLE
Fix bug with Title::newFromDBkey without File namespace

### DIFF
--- a/OpenGraphMeta.class.php
+++ b/OpenGraphMeta.class.php
@@ -43,7 +43,7 @@ class OpenGraphMeta {
 
 		$setMainImage = $parserOutput->getExtensionData( 'setmainimage' );
 		if ( $setMainImage !== null ) {
-			$mainImage = wfFindFile( Title::newFromDBkey( $setMainImage ) );
+			$mainImage = wfFindFile( Title::newFromDBkey( "File:" . $setMainImage ) );
 		} else {
 			$mainImage = false;
 		}


### PR DESCRIPTION
Not working without it.

Title:newFromDBkey should get prefixed titles. 
Or Title:newFromDBkey should be replaced to Title::newFromText( $mainImage, NS_FILE ).